### PR TITLE
Dialogue transition box upon mini game ending to effectively grab player's attention

### DIFF
--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -18,7 +18,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import Slide from '@material-ui/core/Slide';
 
 const Transition = React.forwardRef(function Transition(props, ref) {
-  return <Slide direction="up" ref={ref} {...props} />;
+  return <Slide direction='up' ref={ref} {...props} />;
 });
 
 export const Home = (props) => {
@@ -44,8 +44,8 @@ export const Home = (props) => {
     <div>
       <center>
         <Button
-          variant="contained"
-          color="primary"
+          variant='contained'
+          color='primary'
           disabled={props.game.mini_status !== 'finished'}
           endIcon={<NavigateNextIcon />}
           onClick={props.nextStage}
@@ -56,9 +56,9 @@ export const Home = (props) => {
       <Grid
         container
         spacing={2}
-        direction="row"
-        alignItems="center"
-        justify="space-around"
+        direction='row'
+        alignItems='center'
+        justify='space-around'
         style={{ height: '90vh' }}
       >
         <Grid item lg={1} md={1} sm={false} xs={false} />
@@ -76,22 +76,31 @@ export const Home = (props) => {
         TransitionComponent={Transition}
         keepMounted
         onClose={handleClose}
-        aria-labelledby="alert-dialog-slide-title"
-        aria-describedby="alert-dialog-slide-description"
+        aria-labelledby='alert-dialog-slide-title'
+        aria-describedby='alert-dialog-slide-description'
       >
-        <DialogTitle id="alert-dialog-slide-title">
-          {'Mini Game finished! Continue to next stage'}
+        <DialogTitle id='alert-dialog-slide-title'>
+          {props.nextDisplay === 'End Game'
+            ? 'Congratulations! You are done with this path.'
+            : 'Mini Game finished! Continue to next stage'}
         </DialogTitle>
         <DialogContent>
-          <DialogContentText id="alert-dialog-slide-description">
-            You're ready to move onto the next stage on {props.game.path_name}{' '}
-            pathway. Your score so far is {props.game.total_score}
-          </DialogContentText>
+          {props.nextDisplay === 'End Game' ? (
+            <DialogContentText id='alert-dialog-slide-description'>
+              You are ready to move onto the next path. Your score so far is{' '}
+              {props.game.total_score}
+            </DialogContentText>
+          ) : (
+            <DialogContentText id='alert-dialog-slide-description'>
+              You're ready to move onto the next stage on {props.game.path_name}{' '}
+              pathway. Your score so far is {props.game.total_score}
+            </DialogContentText>
+          )}
         </DialogContent>
         <DialogActions>
           <Button
-            variant="contained"
-            color="primary"
+            variant='contained'
+            color='primary'
             disabled={props.game.mini_status !== 'finished'}
             endIcon={<NavigateNextIcon />}
             onClick={() => {
@@ -103,6 +112,7 @@ export const Home = (props) => {
           </Button>
         </DialogActions>
       </Dialog>
+      )
     </div>
   );
 };

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -18,7 +18,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import Slide from '@material-ui/core/Slide';
 
 const Transition = React.forwardRef(function Transition(props, ref) {
-  return <Slide direction='up' ref={ref} {...props} />;
+  return <Slide direction="up" ref={ref} {...props} />;
 });
 
 export const Home = (props) => {
@@ -44,8 +44,8 @@ export const Home = (props) => {
     <div>
       <center>
         <Button
-          variant='contained'
-          color='primary'
+          variant="contained"
+          color="primary"
           disabled={props.game.mini_status !== 'finished'}
           endIcon={<NavigateNextIcon />}
           onClick={props.nextStage}
@@ -56,9 +56,9 @@ export const Home = (props) => {
       <Grid
         container
         spacing={2}
-        direction='row'
-        alignItems='center'
-        justify='space-around'
+        direction="row"
+        alignItems="center"
+        justify="space-around"
         style={{ height: '90vh' }}
       >
         <Grid item lg={1} md={1} sm={false} xs={false} />
@@ -76,22 +76,22 @@ export const Home = (props) => {
         TransitionComponent={Transition}
         keepMounted
         onClose={handleClose}
-        aria-labelledby='alert-dialog-slide-title'
-        aria-describedby='alert-dialog-slide-description'
+        aria-labelledby="alert-dialog-slide-title"
+        aria-describedby="alert-dialog-slide-description"
       >
-        <DialogTitle id='alert-dialog-slide-title'>
+        <DialogTitle id="alert-dialog-slide-title">
           {props.nextDisplay === 'End Game'
             ? 'Congratulations! You are done with this path.'
             : 'Mini Game finished! Continue to next stage'}
         </DialogTitle>
         <DialogContent>
           {props.nextDisplay === 'End Game' ? (
-            <DialogContentText id='alert-dialog-slide-description'>
+            <DialogContentText id="alert-dialog-slide-description">
               You are ready to move onto the next path. Your score so far is{' '}
               {props.game.total_score}
             </DialogContentText>
           ) : (
-            <DialogContentText id='alert-dialog-slide-description'>
+            <DialogContentText id="alert-dialog-slide-description">
               You're ready to move onto the next stage on {props.game.path_name}{' '}
               pathway. Your score so far is {props.game.total_score}
             </DialogContentText>
@@ -99,8 +99,8 @@ export const Home = (props) => {
         </DialogContent>
         <DialogActions>
           <Button
-            variant='contained'
-            color='primary'
+            variant="contained"
+            color="primary"
             disabled={props.game.mini_status !== 'finished'}
             endIcon={<NavigateNextIcon />}
             onClick={() => {

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -30,12 +30,12 @@ export const Home = (props) => {
   const handleClose = () => {
     setOpen(false);
   };
-
   useEffect(() => {
     if (props.game.mini_status === 'finished') {
       setOpen(true);
     }
   }, [props.game.mini_status]);
+
   const game_type =
     props.rests.length > 0
       ? props.rests[props.game.gameStage - 1].game_type

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -10,11 +10,33 @@ import GameStart from './GameStart';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import NavigateNextIcon from '@material-ui/icons/NavigateNext';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Slide from '@material-ui/core/Slide';
+
+const Transition = React.forwardRef(function Transition(props, ref) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
 
 export const Home = (props) => {
   useEffect(() => {
     props.fetchMiniGameComplete();
   }, []);
+
+  const [open, setOpen] = React.useState(false);
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    console.log(props.game.mini_status);
+    if (props.game.mini_status === 'finished') {
+      setOpen(true);
+    }
+  }, [props.game.mini_status]);
   const game_type =
     props.rests.length > 0
       ? props.rests[props.game.gameStage - 1].game_type
@@ -29,7 +51,7 @@ export const Home = (props) => {
           endIcon={<NavigateNextIcon />}
           onClick={props.nextStage}
         >
-          Continue Your Adventure!
+          {props.nextDisplay}
         </Button>
       </center>
       <Grid
@@ -50,6 +72,38 @@ export const Home = (props) => {
         </Grid>
         <Grid item lg={1} md={1} sm={false} xs={false} />
       </Grid>
+      <Dialog
+        open={open}
+        TransitionComponent={Transition}
+        keepMounted
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-slide-title"
+        aria-describedby="alert-dialog-slide-description"
+      >
+        <DialogTitle id="alert-dialog-slide-title">
+          {'Mini Game finished! Continue to next stage'}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-slide-description">
+            You're ready to move onto the next stage on {props.game.path_name}{' '}
+            pathway. Your score so far is {props.game.total_score}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="contained"
+            color="primary"
+            disabled={props.game.mini_status !== 'finished'}
+            endIcon={<NavigateNextIcon />}
+            onClick={() => {
+              props.nextStage();
+              handleClose();
+            }}
+          >
+            {props.nextDisplay}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 };
@@ -62,6 +116,10 @@ const mapState = (state) => {
     userId: state.auth.id,
     rests: state.rest.rests,
     game: state.game,
+    nextDisplay:
+      state.game.gameStage === state.rest.rests.length
+        ? 'End Game'
+        : 'Continue your Adventure!',
   };
 };
 const mapDispatch = {

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -32,7 +32,6 @@ export const Home = (props) => {
   };
 
   useEffect(() => {
-    console.log(props.game.mini_status);
     if (props.game.mini_status === 'finished') {
       setOpen(true);
     }


### PR DESCRIPTION
- please test locally!
- dialogue transition box to slide from bottom upon minigame status becoming finished (useEffect) and prompt player to move to next stage
- closes #87 