### PR TITLE
Slight improvements to Map and Flappy game mobile compatibility

### DIFF
--- a/client/components/FlappyCake.js
+++ b/client/components/FlappyCake.js
@@ -27,7 +27,7 @@ class FlappyCake extends Component {
         velocity: 0,
         radius: 20,
       },
-      cakes: [{ x: 550, y: 100 }],
+      cakes: [{ x: 325, y: 100 }],
       cakespeed: 1,
       score: 0,
       playing: true,
@@ -115,7 +115,7 @@ class FlappyCake extends Component {
       ) {
         this.setState((state) => {
           const cake = {
-            x: 550,
+            x: 350,
             y: getRandomCoordinates(),
           };
           return {
@@ -160,7 +160,7 @@ class FlappyCake extends Component {
         Use the spacebar or touch/click to fly the penguin so he can catch the
         cakes.
         <div id="game-area">
-          <canvas ref={this.canvasRef} width={400} height={400} />
+          <canvas ref={this.canvasRef} width={350} height={400} />
         </div>
       </div>
     );

--- a/client/components/FlappyCake.js
+++ b/client/components/FlappyCake.js
@@ -33,9 +33,7 @@ class FlappyCake extends Component {
       playing: true,
     };
     this.canvasRef = React.createRef();
-    this.onClick = this.onClick.bind(this);
     this.onKey = this.onKey.bind(this);
-    this.onTouch = this.onTouch.bind(this);
     this.onPoint = this.onPoint.bind(this);
   }
 

--- a/client/components/FlappyCake.js
+++ b/client/components/FlappyCake.js
@@ -36,6 +36,7 @@ class FlappyCake extends Component {
     this.onClick = this.onClick.bind(this);
     this.onKey = this.onKey.bind(this);
     this.onTouch = this.onTouch.bind(this);
+    this.onPoint = this.onPoint.bind(this);
   }
 
   componentDidMount() {
@@ -46,9 +47,8 @@ class FlappyCake extends Component {
       this.update();
       this.draw();
     }, 1000 / 60);
-    document.addEventListener('click', this.onClick);
     document.addEventListener('keydown', this.onKey);
-    document.addEventListener('touchstart', this.onTouch);
+    document.addEventListener('pointerdown', this.onPoint);
   }
 
   componentDidUpdate() {
@@ -56,17 +56,12 @@ class FlappyCake extends Component {
       return;
     }
   }
-  onClick(e) {
-    if (e.target.tagName === 'CANVAS') {
-      this.bump(e);
-    }
-  }
   onKey(e) {
     if (e.code === 'Space' || e.code === 'ArrowUp') {
       this.bump(e);
     }
   }
-  onTouch(e) {
+  onPoint(e) {
     if (e.target.tagName === 'CANVAS') {
       this.bump(e);
     }
@@ -164,7 +159,7 @@ class FlappyCake extends Component {
     }
     return (
       <div id="instructions">
-        Use the spacebar or mouse-click to fly the penguin so he can catch the
+        Use the spacebar or touch/click to fly the penguin so he can catch the
         cakes.
         <div id="game-area">
           <canvas ref={this.canvasRef} width={400} height={400} />

--- a/client/components/Map.js
+++ b/client/components/Map.js
@@ -86,11 +86,26 @@ class _Map extends React.Component {
 
   render() {
     return (
-      <React.Fragment>
-        <div style={{ height: '90%', width: '100%' }}>
-          <center>
-            <InfoWindow gameStage={this.props.gameStage} />
-          </center>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          alignContent: 'space-between',
+        }}
+      >
+        <center>
+          <InfoWindow gameStage={this.props.gameStage} />
+        </center>
+        <div
+          style={{
+            height: '100%',
+            width: '90%',
+            margin: 'auto',
+          }}
+        >
           <GoogleMapReact
             bootstrapURLKeys={{
               key: 'AIzaSyCnNLEaNM_3zfMo0yHe - nINMSUPPfyJwUI',
@@ -110,7 +125,7 @@ class _Map extends React.Component {
             ))}
           </GoogleMapReact>
         </div>
-      </React.Fragment>
+      </div>
     );
   }
 }

--- a/client/components/Style/FlappyCake.css
+++ b/client/components/Style/FlappyCake.css
@@ -1,6 +1,7 @@
 #instructions {
   margin-top: -20px;
   margin-bottom: 20px;
+  padding: 1rem;
 }
 
 #game-message {
@@ -8,6 +9,6 @@
 }
 
 #game-area {
-  position: relative;
+  margin: 1rem;
   touch-action: none;
 }

--- a/client/components/Style/FlappyCake.css
+++ b/client/components/Style/FlappyCake.css
@@ -9,7 +9,5 @@
 
 #game-area {
   position: relative;
-  margin-top: 15px;
-  margin-bottom: 25px;
   touch-action: none;
 }


### PR DESCRIPTION
- flappy now uses 'pointer' events that work with both click and touch
- Map uses slightly less space to prevent scroll issues on mobile
- mobile game is out of view on mobile at default unfortunately - consider swapping map and minigames?
- -or setting gameStart windows to be full height instead of expanding unexpectedly