### PR TITLE
Remove FB login ability from public release temporarily

### DIFF
--- a/client/components/Auth-Form.js
+++ b/client/components/Auth-Form.js
@@ -86,9 +86,9 @@ const AuthForm = (props) => {
             </Grid>
           </form>
           <Box m={3} pt={10}>
-            <Grid item>
+            {/* <Grid item>
               <Facebook />
-            </Grid>
+            </Grid> */}
             <Box pt={2}>
               <Grid item>
                 {window.githubURL && (


### PR DESCRIPTION
- FB login is in dev mode, unable to let public log in until further work is put into privacy policy. Commenting for public stability until ready to re-enable facebook social login